### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ana0378/d3cf216e-d0d3-4d66-b2f3-9d3d6f9b24bf/62f6c502-db02-437b-acbf-c7858aef7383/_apis/work/boardbadge/22179db3-2c61-4f51-bacb-5acf2fcde820)](https://dev.azure.com/ana0378/d3cf216e-d0d3-4d66-b2f3-9d3d6f9b24bf/_boards/board/t/62f6c502-db02-437b-acbf-c7858aef7383/Microsoft.RequirementCategory)
 # jss-sandbox
 I am a Sitecore and JavaScript developer who is currently learning the Sitecore JavaScript Services (JSS) SDK. My goal is to build a small sandbox site where I can explore JSS features and try out the API. I want to take typical challenges that developers encounter on projects and explore how they are handled in the JSS world.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ana0378/d3cf216e-d0d3-4d66-b2f3-9d3d6f9b24bf/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.